### PR TITLE
Move to always filter on `list[str]` rather than `str`

### DIFF
--- a/mcpunk/file_chunk.py
+++ b/mcpunk/file_chunk.py
@@ -38,7 +38,7 @@ class Chunk(BaseModel):
 
     def matches_filter(
         self,
-        filter_: str | None | list[str],
+        filter_: None | list[str],
         filter_on: Literal["name", "content", "name_or_content"],
     ) -> bool:
         """Return True if the chunk's name matches the given filter.

--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -40,7 +40,7 @@ ToolResponseSingleItem = mcp_types.TextContent | mcp_types.ImageContent | mcp_ty
 ToolResponseSequence = Sequence[ToolResponseSingleItem]
 ToolResponse = ToolResponseSequence | ToolResponseSingleItem
 FilterType = Annotated[
-    str | list[str] | None,
+    list[str] | None,
     Field(description="Match if any of these strings appear. Match all if None/null."),
 ]
 
@@ -546,7 +546,7 @@ if __name__ == "__main__":
     print(sum(len(f.contents) for f in _proj.files if f.ext == ".py"), "chars")
     list_files_by_chunk_contents(
         project_name="mcpunk",
-        chunk_contents_filter="desktop",
+        chunk_contents_filter=["desktop"],
     )
     _list_chunks_in_file(
         proj_file=ProjectFile(

--- a/mcpunk/util.py
+++ b/mcpunk/util.py
@@ -59,7 +59,7 @@ def create_file_tree(
     paths: set[Path],
     expand_parent_directories: bool = True,
     limit_depth_from_root: int | None = None,
-    filter_: str | None | list[str] = None,
+    filter_: None | list[str] = None,
 ) -> dict[str, Any] | None:
     """Create a tree structure from a set of file and directory paths.
 
@@ -160,7 +160,7 @@ def rand_str(n: int = 10, chars: str = ascii_lowercase) -> str:
     return "".join(random.choice(chars) for _ in range(n))
 
 
-def matches_filter(filter_: str | None | list[str], data: str | None) -> bool:
+def matches_filter(filter_: None | list[str], data: str | None) -> bool:
     """Return True if the data matches the given filter.
 
     filter_ can be:
@@ -174,8 +174,6 @@ def matches_filter(filter_: str | None | list[str], data: str | None) -> bool:
         return True
     if data is None:
         return False
-    if isinstance(filter_, str):
-        return filter_ in data
     if isinstance(filter_, list):
         return any(x in data for x in filter_)
     assert_never(filter_)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,7 +80,7 @@ def test_create_file_tree_with_filter(tmp_path: Path) -> None:
         tmp_path / "data.txt",
     }
 
-    result = create_file_tree(project_root=tmp_path, paths=paths, filter_=".py")
+    result = create_file_tree(project_root=tmp_path, paths=paths, filter_=[".py"])
     assert result == {
         "root": {
             "f": ["main.py", "test.py"],
@@ -142,11 +142,6 @@ def test_matches_filter() -> None:
     # Test None filter
     assert matches_filter(None, "test") is True
     assert matches_filter(None, None) is True
-
-    # Test string filter
-    assert matches_filter("abc", "abcdef") is True
-    assert matches_filter("xyz", "abcdef") is False
-    assert matches_filter("abc", None) is False
 
     # Test list filter
     assert matches_filter(["abc", "def"], "abcdef") is True


### PR DESCRIPTION
With `str`, claude tends to send strings like '"search_term"' which includes double quotes. A bit of messiness around JSON-encoded data in request parameters. Bit of a discussion in https://github.com/jlowin/fastmcp/pull/31

To sidestep this issue, let's just always use list[str] 🤷