### PR TITLE
Avoid output to stdout and stderr

### DIFF
--- a/mcpunk/dependencies.py
+++ b/mcpunk/dependencies.py
@@ -60,7 +60,6 @@ class Dependencies(metaclass=Singleton):
             settings = self.settings()
             self._state.engine = create_engine(
                 f"sqlite:///{settings.db_path}?check_same_thread=true&timeout=10&uri=true",
-                echo=settings.db_echo,
             )
         return self._state.engine
 

--- a/mcpunk/run_mcp_server.py
+++ b/mcpunk/run_mcp_server.py
@@ -44,6 +44,7 @@ Can add to claude like
 
 # This file is a target for `fastmcp run .../run_mcp_server.py`
 import logging
+import sys
 
 from mcpunk.db import init_db
 from mcpunk.dependencies import Dependencies
@@ -51,24 +52,44 @@ from mcpunk.tools import mcp
 
 
 def _setup_logging() -> logging.Logger:
+    """Aggressively control global logging.
+
+    It seems that some MCP clients are messed up by looking at stderr,
+    here we remove all log handlers and configure them ourselves with
+    careful control.
+    """
     settings = Dependencies().settings()
-    _logger = logging.getLogger("mcpunk")
-    _logger.setLevel(settings.log_level)
+
+    root_logger = logging.getLogger()
+
+    # Remove any existing handlers
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        handler.close()
+
+    root_logger.setLevel(settings.log_level)
+
+    formatter = logging.Formatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+    if settings.enable_stderr_logging:
+        stderr_handler = logging.StreamHandler(sys.stderr)
+        stderr_handler.setLevel(settings.log_level)
+        stderr_handler.setFormatter(formatter)
+        root_logger.addHandler(stderr_handler)
+
     if settings.enable_log_file:
         log_path = settings.log_file.expanduser().absolute()
         log_path.parent.mkdir(parents=True, exist_ok=True)
         file_handler = logging.FileHandler(log_path)
         file_handler.setLevel(settings.log_level)
+        file_handler.setFormatter(formatter)
+        root_logger.addHandler(file_handler)
 
-        file_handler.setFormatter(
-            logging.Formatter(
-                "%(asctime)s - %(name)s - %(levelname)s - %(message)s",
-                datefmt="%Y-%m-%d %H:%M:%S",
-            ),
-        )
-        _logger.addHandler(file_handler)
-
-    return _logger
+    # Get module logger (will inherit from root)
+    return logging.getLogger(__name__)
 
 
 logger = _setup_logging()

--- a/mcpunk/settings.py
+++ b/mcpunk/settings.py
@@ -9,9 +9,6 @@ class Settings(BaseSettings):
     # SQLite database path
     db_path: Path = Path("~/.mcpunk/db.sqlite").expanduser()
 
-    # Enable SQLAlchemy query logging
-    db_echo: bool = True
-
     enable_log_file: bool = True
     log_file: Path = Path("~/.mcpunk/mcpunk.log").expanduser()
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "FATAL", "CRITICAL"] = "DEBUG"

--- a/mcpunk/settings.py
+++ b/mcpunk/settings.py
@@ -9,6 +9,11 @@ class Settings(BaseSettings):
     # SQLite database path
     db_path: Path = Path("~/.mcpunk/db.sqlite").expanduser()
 
+    # I believe that MCP clients should not look at stderr, but it seems some do
+    # which completely messes with things. Suggest leaving this off and relying
+    # on the log *file* instead.
+    enable_stderr_logging: bool = False
+
     enable_log_file: bool = True
     log_file: Path = Path("~/.mcpunk/mcpunk.log").expanduser()
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "FATAL", "CRITICAL"] = "DEBUG"


### PR DESCRIPTION
Previously sqlalchemy was outputting to stdout which messed with MCP operation.

And it seems some MCP clients (cline) can be messed up by stderr output. But not certain. To be conservative I have configured MCPunk to aggressively control logging.

With this PR
1. No longer get big error message in claude desktop when starting (although despite that it did still work)
2. Works nicely with cline