### PR TITLE
Cache AST

### DIFF
--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -547,12 +547,16 @@ def _filter_files_by_chunk(
 
 
 if __name__ == "__main__":
+    import time
+
     # mark_task_done(task_id=10, outcome="ok", follow_up_criticality="low")
+    t1 = time.monotonic()
     configure_project(
         root_path=pathlib.Path("~/git/mcpunk"),
         project_name="mcpunk",
     )
-    print()
+    t2 = time.monotonic()
+    print(f"Configured project in {(t2 - t1) * 1000:.2f}ms")
     _proj = PROJECTS["mcpunk"].chunk_project
     print(len([f for f in _proj.files if f.ext == ".py"]), "files")
     print(sum(len(f.contents.splitlines()) for f in _proj.files if f.ext == ".py"), "lines")


### PR DESCRIPTION
Should make loading a project a little faster. Currently multiprocessing overhead is quite large for smaller projects, so will tweak in future to e.g. use no multiprocessing for smaller projects or smaller number of processes. e.g. if you modify the code to not use multiprocessing, then configuring this mcpunk project, it drops from ~300ms to ~150ms after this PR - but with full multiprocessing no real difference as it seems multiprocessing overhead dominates.