### PR TITLE
Skip empty python chunks

### DIFF
--- a/mcpunk/file_chunkers.py
+++ b/mcpunk/file_chunkers.py
@@ -61,15 +61,23 @@ class PythonChunker(BaseChunker):
         callables = Callable.from_source_code(self.source_code)
         imports = "\n".join(extract_imports(self.source_code))
         module_level_statements = "\n".join(extract_module_statements(self.source_code))
-        chunks: list[Chunk] = [
-            Chunk(category=ChunkCategory.imports, name="<imports>", line=None, content=imports),
-            Chunk(
-                category=ChunkCategory.module_level,
-                name="<module_level_statements>",
-                line=None,
-                content=module_level_statements,
-            ),
-        ]
+
+        chunks: list[Chunk] = []
+
+        if imports.strip() != "":
+            chunks.append(
+                Chunk(category=ChunkCategory.imports, name="<imports>", line=None, content=imports),
+            )
+        if module_level_statements.strip() != "":
+            chunks.append(
+                Chunk(
+                    category=ChunkCategory.module_level,
+                    name="<module_level_statements>",
+                    line=None,
+                    content=module_level_statements,
+                ),
+            )
+
         chunks.extend(
             Chunk(
                 category=ChunkCategory.callable,

--- a/tests/file_chunkers/test_python_chunker.py
+++ b/tests/file_chunkers/test_python_chunker.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+
+from mcpunk.file_chunkers import PythonChunker
+
+
+def test_python_chunker_basic() -> None:
+    """A basic test that it picks out key elements.
+
+    Notably the picking apart of python code into callables, imports, and module-level
+    statements is tested elsewhere.
+    """
+    source_code = """\
+from typing import List
+import os
+
+x = 1
+
+def func1(a: int) -> str:
+    return str(a)
+
+y = 2
+
+class MyClass:
+    def method1(self) -> None:
+        pass
+
+    @property
+    def prop1(self) -> int:
+        return 42
+"""
+    assert PythonChunker.can_chunk("", Path("test.py"))
+    assert not PythonChunker.can_chunk("", Path("test.txt"))
+
+    chunks = PythonChunker(source_code, Path("test.py")).chunk_file()
+    chunks = sorted(chunks, key=lambda x: x.line if x.line is not None else -1)
+
+    assert [x.name for x in chunks] == [
+        "<imports>",
+        "<module_level_statements>",
+        "func1",
+        "MyClass",
+        "method1",
+        "prop1",
+    ]
+
+    # Test categories
+    assert chunks[0].category.value == "imports"
+    assert chunks[1].category.value == "module_level"
+    assert chunks[2].category.value == "callable"
+    assert chunks[3].category.value == "callable"
+    assert chunks[4].category.value == "callable"
+    assert chunks[5].category.value == "callable"
+
+    # Test content
+    assert chunks[0].content == "from typing import List\nimport os"
+    assert chunks[1].content == "x = 1\ndef func1...\ny = 2\nclass MyClass..."
+
+    assert chunks[2].content == "def func1(a: int) -> str:\n    return str(a)"
+    assert chunks[2].line == 6
+
+    assert "class MyClass:" in chunks[3].content
+    assert chunks[3].line == 11
+
+    assert "def method1(self)" in chunks[4].content
+    assert chunks[4].line == 12
+
+    assert "@property" in chunks[5].content
+    assert "def prop1(self)" in chunks[5].content
+    assert chunks[5].line == 16

--- a/tests/file_chunkers/test_python_chunker.py
+++ b/tests/file_chunkers/test_python_chunker.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from mcpunk.file_chunk import ChunkCategory
 from mcpunk.file_chunkers import PythonChunker
 
@@ -118,3 +120,8 @@ class MyClass:
     assert module_level.category == ChunkCategory.module_level
     # We should still have module level statements, just with skeleton of the callables:
     assert module_level.content == "def func1...\nclass MyClass..."
+
+
+def test_python_chunker_invalid_syntax() -> None:
+    with pytest.raises(Exception, match=".*"):
+        _ = PythonChunker("x = (1", Path("test.py")).chunk_file()


### PR DESCRIPTION
Previously, if a file had no imports or module level statements they'd be included as chunks with empty string contents. Now, they're totally excluded. module-level statements will still include things like `def my_func...\nclass MyClass...` even with no other module level statements though. 