### PR TITLE
Rework file tree

### DIFF
--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -318,8 +318,12 @@ def list_all_files_in_project(
     )
     if data is None:
         return MCPToolOutput(text="No paths").render()
-    else:
+    elif isinstance(data, str):
+        return MCPToolOutput(text=data).render()
+    elif isinstance(data, dict):
         return MCPToolOutput(jsonable=data).render()
+    else:
+        assert_never(data)
 
 
 @mcp.tool()
@@ -561,7 +565,12 @@ def _filter_files_by_chunk(
     data = create_file_tree(project_root=project.root, paths=matching_files)
     if data is None:
         return MCPToolOutput(text="No files found")
-    return MCPToolOutput(jsonable=data)
+    elif isinstance(data, str):
+        return MCPToolOutput(text=data)
+    elif isinstance(data, dict):
+        return MCPToolOutput(jsonable=data)
+    else:
+        assert_never(data)
 
 
 if __name__ == "__main__":

--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -312,7 +312,6 @@ def list_all_files_in_project(
     data = create_file_tree(
         project_root=project.root,
         paths={x.abs_path for x in project.chunk_project.files},
-        expand_parent_directories=True,
         limit_depth_from_root=limit_depth_from_root,
         filter_=path_filter,
     )
@@ -320,8 +319,6 @@ def list_all_files_in_project(
         return MCPToolOutput(text="No paths").render()
     elif isinstance(data, str):
         return MCPToolOutput(text=data).render()
-    elif isinstance(data, dict):
-        return MCPToolOutput(jsonable=data).render()
     else:
         assert_never(data)
 
@@ -567,8 +564,6 @@ def _filter_files_by_chunk(
         return MCPToolOutput(text="No files found")
     elif isinstance(data, str):
         return MCPToolOutput(text=data)
-    elif isinstance(data, dict):
-        return MCPToolOutput(jsonable=data)
     else:
         assert_never(data)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 from string import ascii_lowercase
 
@@ -72,8 +73,9 @@ def test_create_file_tree(tmp_path: Path) -> None:
         paths=paths,
     )
 
+    sep = os.path.sep
     expected = (
-        ".: file3.txt\ndir1: file1.txt; other.txt\ndir1/subdir: file2.txt\n"
+        f".: file3.txt\ndir1: file1.txt; other.txt\ndir1{sep}subdir: file2.txt\n"
         "logs: app.log; error.log\n"
     )
     assert result == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,48 +41,42 @@ def test_log_inputs(
 
 
 def test_create_file_tree(tmp_path: Path) -> None:
-    """Test create_file_tree generates correct tree structure."""
+    """Test create_file_tree generates correct compact text output."""
     # Set up test files
     (tmp_path / "dir1").mkdir()
     (tmp_path / "dir1/file1.txt").touch()
+    (tmp_path / "dir1/other.txt").touch()
     (tmp_path / "dir1/subdir").mkdir()
     (tmp_path / "dir1/subdir/file2.txt").touch()
     (tmp_path / "file3.txt").touch()
     (tmp_path / "dir2/dir4/dir5").mkdir(parents=True)
+    (tmp_path / "logs").mkdir()
+    (tmp_path / "logs/app.log").touch()
+    (tmp_path / "logs/error.log").touch()
 
     paths = {
         tmp_path / "dir1",
         tmp_path / "dir1/file1.txt",
+        tmp_path / "dir1/other.txt",
         tmp_path / "dir1/subdir",
         tmp_path / "dir1/subdir/file2.txt",
         tmp_path / "file3.txt",
         tmp_path / "dir2/dir4/dir5",
+        tmp_path / "logs",
+        tmp_path / "logs/app.log",
+        tmp_path / "logs/error.log",
     }
 
     result = create_file_tree(
         project_root=tmp_path,
         paths=paths,
-        force_response_structure="dict",
     )
 
-    assert result == {
-        "root": {
-            "dir1": {
-                "f": ["file1.txt"],
-                "subdir": {
-                    "f": ["file2.txt"],
-                },
-            },
-            "dir2": {
-                "dir4": {
-                    "dir5": {"f": "..."},
-                    "f": "...",
-                },
-                "f": "...",
-            },
-            "f": ["file3.txt"],
-        },
-    }
+    expected = (
+        ".: file3.txt\ndir1: file1.txt; other.txt\ndir1/subdir: file2.txt\n"
+        "logs: app.log; error.log\n"
+    )
+    assert result == expected
 
 
 def test_create_file_tree_with_filter(tmp_path: Path) -> None:
@@ -101,17 +95,13 @@ def test_create_file_tree_with_filter(tmp_path: Path) -> None:
         project_root=tmp_path,
         paths=paths,
         filter_=[".py"],
-        force_response_structure="dict",
     )
-    assert result == {
-        "root": {
-            "f": ["main.py", "test.py"],
-        },
-    }
+    assert result == ".: main.py; test.py\n"
 
 
 def test_create_file_tree_depth_limit(tmp_path: Path) -> None:
     """Test create_file_tree with depth limit."""
+    (tmp_path / "file0.txt").touch()
     (tmp_path / "dir1/dir2/dir3").mkdir(parents=True)
     (tmp_path / "dir1/file1.txt").touch()
     (tmp_path / "dir1/dir2/file2.txt").touch()
@@ -120,6 +110,7 @@ def test_create_file_tree_depth_limit(tmp_path: Path) -> None:
     paths = {
         tmp_path / p
         for p in [
+            "file0.txt",
             "dir1",
             "dir1/file1.txt",
             "dir1/dir2",
@@ -133,18 +124,8 @@ def test_create_file_tree_depth_limit(tmp_path: Path) -> None:
         project_root=tmp_path,
         paths=paths,
         limit_depth_from_root=2,
-        force_response_structure="dict",
     )
-
-    assert result == {
-        "root": {
-            "dir1": {
-                "f": ["file1.txt"],
-                "dir2": {"f": "..."},
-            },
-            "f": "...",
-        },
-    }
+    assert result == ".: file0.txt\ndir1: file1.txt\n"
 
 
 def test_rand_str() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -62,6 +62,7 @@ def test_create_file_tree(tmp_path: Path) -> None:
     result = create_file_tree(
         project_root=tmp_path,
         paths=paths,
+        force_response_structure="dict",
     )
 
     assert result == {
@@ -96,7 +97,12 @@ def test_create_file_tree_with_filter(tmp_path: Path) -> None:
         tmp_path / "data.txt",
     }
 
-    result = create_file_tree(project_root=tmp_path, paths=paths, filter_=[".py"])
+    result = create_file_tree(
+        project_root=tmp_path,
+        paths=paths,
+        filter_=[".py"],
+        force_response_structure="dict",
+    )
     assert result == {
         "root": {
             "f": ["main.py", "test.py"],
@@ -123,7 +129,12 @@ def test_create_file_tree_depth_limit(tmp_path: Path) -> None:
         ]
     }
 
-    result = create_file_tree(project_root=tmp_path, paths=paths, limit_depth_from_root=2)
+    result = create_file_tree(
+        project_root=tmp_path,
+        paths=paths,
+        limit_depth_from_root=2,
+        force_response_structure="dict",
+    )
 
     assert result == {
         "root": {


### PR DESCRIPTION
previously it returns a JSON thingo with the intention of just having to list out directory names once. But it's a bit silly, a bit annoying to read. I've just simplified it down to return plain text like below. Makes response size in chars about half or so the size it was before.

```
dir1: file1.txt
dir2/dir3: file2.txt; file3.txt
...
```