### PR TITLE
Auto Reload on File Changes

### DIFF
--- a/mcpunk/file_breakdown.py
+++ b/mcpunk/file_breakdown.py
@@ -202,7 +202,7 @@ class Project:
         files_per_parallel_worker: int = 100,
         file_watch_refresh_freq_seconds: float = 0.1,
     ) -> None:
-        self.root = root
+        self.root = root.expanduser().absolute()
         self.files_per_parallel_worker = files_per_parallel_worker
         self.file_map: dict[Path, File] = {}
 
@@ -214,6 +214,8 @@ class Project:
         self.git_repo = git_repo
 
         self._init_from_root_dir(root)
+
+        # Note potential that if a file is modified here it won't be picked up.
 
         self.observer = Observer()
         self.observer.schedule(
@@ -272,7 +274,7 @@ class Project:
         else:
             # Exclude specific top-level directories
             # TODO: make this configurable
-            ignore_dirs = {".venv", "build", ".git", "__pycache__"}  # customize this set
+            ignore_dirs = {".venv", "build", ".git", "__pycache__"}
 
             for path in root.iterdir():
                 if path.is_dir() and path.name not in ignore_dirs:

--- a/mcpunk/file_breakdown.py
+++ b/mcpunk/file_breakdown.py
@@ -40,7 +40,7 @@ ALL_CHUNKERS: list[type[BaseChunker]] = [
 logger = logging.getLogger(__name__)
 
 
-class ProjectFileHandler(FileSystemEventHandler):
+class _ProjectFileHandler(FileSystemEventHandler):
     def __init__(self, project: "Project") -> None:
         self.project = project
         self._timers: dict[Path, Timer] = {}
@@ -172,7 +172,11 @@ class Project:
         self._init_from_root_dir(root)
 
         self.observer = Observer()
-        self.observer.schedule(ProjectFileHandler(self), str(self.root), recursive=True)
+        self.observer.schedule(
+            event_handler=_ProjectFileHandler(self),
+            path=str(self.root),
+            recursive=True,
+        )
         self.observer.start()
 
     @property

--- a/mcpunk/settings.py
+++ b/mcpunk/settings.py
@@ -47,6 +47,12 @@ class Settings(BaseSettings):
     # will become available again for pickup.
     task_queue_visibility_timeout_seconds: int = 300
 
+    # How long to wait between refreshing files modified on disk. This allows files
+    # to queue up and be refreshed in parallel if many are modified (e.g. switching
+    # branches), and it generally also avoids churn when e.g. an IDE creates temporary
+    # files during save (though this is not a guarantee).
+    file_watch_refresh_freq_seconds: float = 0.1
+
     @property
     def task_queue_visibility_timeout(self) -> timedelta:
         return timedelta(seconds=self.task_queue_visibility_timeout_seconds)

--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -11,6 +11,7 @@ from fastmcp import FastMCP
 from git import Repo
 from pydantic import (
     BaseModel,
+    ConfigDict,
     Field,
     model_validator,
 )
@@ -51,6 +52,8 @@ class ToolProject(BaseModel):
     """
 
     chunk_project: FileBreakdownProject
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
 
     @property
     def root(self) -> pathlib.Path:
@@ -252,7 +255,7 @@ def configure_project(
     path = root_path.expanduser().absolute()
     if project_name in PROJECTS:
         raise ValueError(f"Project {project_name} already exists")
-    project = ToolProject(chunk_project=FileBreakdownProject.from_root_dir(path))
+    project = ToolProject(chunk_project=FileBreakdownProject(root=path))
     PROJECTS[project_name] = project
     return MCPToolOutput(
         text=(

--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -255,7 +255,12 @@ def configure_project(
     path = root_path.expanduser().absolute()
     if project_name in PROJECTS:
         raise ValueError(f"Project {project_name} already exists")
-    project = ToolProject(chunk_project=FileBreakdownProject(root=path))
+    project = ToolProject(
+        chunk_project=FileBreakdownProject(
+            root=path,
+            file_watch_refresh_freq_seconds=deps.settings().file_watch_refresh_freq_seconds,
+        ),
+    )
     PROJECTS[project_name] = project
     return MCPToolOutput(
         text=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "sqlalchemy~=2.0.36",
     "beautifulsoup4~=4.12.3",
     "uvicorn>=0.34.0,<1.0.0",
+    "watchdog~=6.0.0",
 ]
 
 [project.scripts]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import hashlib
 from collections.abc import Generator
 from pathlib import Path
 
@@ -9,8 +10,9 @@ from mcpunk.settings import Settings
 
 
 @pytest.fixture(scope="function", autouse=True)
-def fresh_db(tmp_path: Path) -> Generator[None, None, None]:
+def fresh_db(tmp_path_factory: pytest.TempPathFactory) -> Generator[None, None, None]:
     """Fiddle settings such that we have a fresh database"""
+    tmp_path = tmp_path_factory.mktemp("test")
     settings = Settings(db_path=tmp_path / "test.db")
     assert not settings.db_path.absolute().exists()
     with deps.override(settings_partial=settings):
@@ -27,3 +29,31 @@ def fiddle_settings() -> Generator[None, None, None]:
     )
     with deps.override(settings_partial=settings):
         yield
+
+
+@pytest.fixture
+def test_id(request: pytest.FixtureRequest) -> str:
+    """A (probably) unique ID for each test"""
+    test_hash = hashlib.md5(request.node.nodeid.encode()).hexdigest()  # noqa: S324
+    assert len(test_hash) == 32
+    return f"{request.node.name[:(60 - len(test_hash) - 1)]}_{test_hash}"
+
+
+class FileSet:
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def add_file(self, fname: str, src: str) -> None:
+        new_path = self.root / fname
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        new_path.write_text(src)
+
+
+@pytest.fixture
+def basic_file_set(tmp_path_factory: pytest.TempPathFactory) -> FileSet:
+    """A basic file set with two files."""
+    tmp_path = tmp_path_factory.mktemp("test")
+    fs = FileSet(tmp_path)
+    fs.add_file("a.py", "a=1")
+    fs.add_file("b.py", "b=2\ndef f(a: int=1):\n    return a")
+    return fs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def fiddle_settings() -> Generator[None, None, None]:
     """Fiddle misc settings for consistency in testing."""
     settings = Settings(
         include_chars_in_response=False,
+        file_watch_refresh_freq_seconds=0.0,
     )
     with deps.override(settings_partial=settings):
         yield

--- a/tests/test_file_breakdown_project.py
+++ b/tests/test_file_breakdown_project.py
@@ -1,0 +1,382 @@
+import logging
+import sys
+import time
+from pathlib import Path
+
+import pytest
+from git import Repo
+
+from mcpunk.file_breakdown import Project as FileBreakdownProject
+from mcpunk.file_chunk import ChunkCategory
+from tests.conftest import FileSet
+
+
+def test_project_initialization(basic_file_set: FileSet) -> None:
+    project = FileBreakdownProject(root=basic_file_set.root)
+    assert project.root == basic_file_set.root
+    assert len(project.files) == 2
+    assert set(project.file_map.keys()) == {
+        basic_file_set.root / "a.py",
+        basic_file_set.root / "b.py",
+    }
+
+
+def test_project_file_loading(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("test.py", "import foo")
+
+    project = FileBreakdownProject(root=fs.root)
+    assert len(project.files) == 1
+    loaded_file = project.file_map[fs.root / "test.py"]
+    assert loaded_file.contents == "import foo"
+    assert loaded_file.ext == ".py"
+    assert [c.category for c in loaded_file.chunks] == [ChunkCategory.imports]
+
+
+def test_project_mixed_files_and_locations(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    # Top level files
+    fs.add_file("script.py", "import blah")
+    fs.add_file("readme.md", "# Title\n## Section")
+    fs.add_file("config.xyz", "some: config")
+
+    # Deep nested files
+    fs.add_file("src/lib/utils.py", "x = 1")
+    fs.add_file("docs/api/spec.md", "# API\n## Endpoints")
+    fs.add_file("config/env/dev.xyz", "env: dev")
+
+    project = FileBreakdownProject(root=fs.root)
+    assert len(project.files) == 6
+
+    # Check Python files were chunked correctly
+    script_file = project.file_map[fs.root / "script.py"]
+    utils_file = project.file_map[fs.root / "src/lib/utils.py"]
+    assert [c.category for c in script_file.chunks] == [ChunkCategory.imports]
+    assert [c.category for c in utils_file.chunks] == [ChunkCategory.module_level]
+
+    # Check Markdown files were chunked correctly
+    readme_file = project.file_map[fs.root / "readme.md"]
+    spec_file = project.file_map[fs.root / "docs/api/spec.md"]
+    assert all(c.category == ChunkCategory.markdown_section for c in readme_file.chunks)
+    assert all(c.category == ChunkCategory.markdown_section for c in spec_file.chunks)
+
+    # Check unknown extensions used whole file chunker
+    config_file = project.file_map[fs.root / "config.xyz"]
+    env_file = project.file_map[fs.root / "config/env/dev.xyz"]
+    assert all(c.category == ChunkCategory.whole_file for c in config_file.chunks)
+    assert all(c.category == ChunkCategory.whole_file for c in env_file.chunks)
+
+
+def test_project_git_detection_without_git(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("test.py", "x = 1")
+
+    project = FileBreakdownProject(root=fs.root)
+    assert project.git_repo is None
+
+
+def test_project_git_detection_with_git(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("test.py", "x = 1")
+    # Initialize actual git repo
+    Repo.init(fs.root)
+
+    project = FileBreakdownProject(root=fs.root)
+    assert project.git_repo is not None
+
+
+def test_project_non_existent_root(tmp_path: Path) -> None:
+    non_existent = tmp_path / "does_not_exist"
+    with pytest.raises(ValueError, match="does not exist"):
+        FileBreakdownProject(root=non_existent)
+
+
+@pytest.mark.skipif(sys.platform not in ("linux", "darwin"), reason="Dumb test relies on chmod")
+def test_project_handles_unreadable_file(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("good.py", "x = 1")
+    bad_file = fs.root / "bad.py"
+    bad_file.touch()
+    bad_file.chmod(0o000)  # Make unreadable
+
+    project = FileBreakdownProject(root=fs.root)
+    assert len(project.files) == 1  # Should have just the good file
+    assert (fs.root / "good.py") in project.file_map
+
+    # Good file should be chunked normally
+    good_file = project.file_map[fs.root / "good.py"]
+    assert [c.category for c in good_file.chunks] == [ChunkCategory.module_level]
+
+
+def test_project_handles_bad_syntax_file(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("good.py", "x = 1")
+    fs.add_file("bad_syntax.py", "x = ")
+
+    project = FileBreakdownProject(root=fs.root)
+    assert len(project.files) == 2
+    assert (fs.root / "good.py") in project.file_map
+    assert (fs.root / "bad_syntax.py") in project.file_map
+
+    # Bad syntax should fallback to whole file chunker
+    bad_syntax_file = project.file_map[fs.root / "bad_syntax.py"]
+    assert [c.category for c in bad_syntax_file.chunks] == [ChunkCategory.whole_file]
+
+    # Good file should be chunked normally
+    good_file = project.file_map[fs.root / "good.py"]
+    assert [c.category for c in good_file.chunks] == [ChunkCategory.module_level]
+
+
+def test_project_parallel_processing(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A bit of a chunky one as it results in multiprocessing.
+
+    # e.g. in CI we only have two cores. For reliable testing, patch this.
+    monkeypatch.setattr("os.cpu_count", lambda: 8)
+
+    fs = FileSet(tmp_path)
+
+    # First add 10 files - should use single worker
+    for i in range(10):
+        fs.add_file(f"file_{i}.py", f"x_{i} = {i}")
+    caplog.set_level(logging.DEBUG)
+    project = FileBreakdownProject(root=fs.root, files_per_parallel_worker=10)
+    assert len(project.files) == 10
+    assert "workers" not in caplog.text.lower()
+
+    # Add 20 more files - should now use multiple workers
+    for i in range(10, 30):
+        fs.add_file(f"file_{i}.py", f"x_{i} = {i}")
+    project = FileBreakdownProject(root=fs.root, files_per_parallel_worker=10)
+    assert len(project.files) == 30
+    assert "Using 3 workers to process 30 files" in caplog.text
+
+
+def test_project_watch_new_file(tmp_path: Path) -> None:
+    # Init project
+    fs = FileSet(tmp_path)
+    fs.add_file("test.py", "def test(): pass")
+    project = FileBreakdownProject(root=fs.root, file_watch_refresh_freq_seconds=0.0)
+
+    # Add new file and wait for refresh
+    fs.add_file("new.py", "import new")
+    for _ in range(2_000):
+        if (fs.root / "new.py") in project.file_map:
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File not updated")
+
+    assert (fs.root / "new.py") in project.file_map
+    new_file = project.file_map[fs.root / "new.py"]
+    assert new_file.contents == "import new"
+    assert [c.category for c in new_file.chunks] == [ChunkCategory.imports]
+
+
+def test_project_watch_modify_file(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("test.py", "def test(): pass")
+    project = FileBreakdownProject(root=fs.root, file_watch_refresh_freq_seconds=0.0)
+
+    # Modify file and wait for refresh
+    (fs.root / "test.py").write_text("import modified")
+    for _ in range(2_000):
+        if project.file_map[fs.root / "test.py"].contents == "import modified":
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File not updated")
+
+    modified_file = project.file_map[fs.root / "test.py"]
+    assert modified_file.contents == "import modified"
+    assert [c.category for c in modified_file.chunks] == [ChunkCategory.imports]
+
+
+def test_project_watch_delete_file(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("test.py", "def test(): pass")
+    project = FileBreakdownProject(root=fs.root, file_watch_refresh_freq_seconds=0.0)
+    assert len(project.file_map) == 1
+
+    # Delete file and wait for refresh
+    (fs.root / "test.py").unlink()
+    for _ in range(2_000):
+        if (fs.root / "test.py") not in project.file_map:
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File not updated")
+
+    assert (fs.root / "test.py") not in project.file_map
+
+
+def test_project_watch_delete_and_recreate_file(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("test.py", "def test(): pass")
+    project = FileBreakdownProject(root=fs.root, file_watch_refresh_freq_seconds=0.0)
+    assert len(project.file_map) == 1
+
+    # Delete file and wait for refresh
+    (fs.root / "test.py").unlink()
+    for _ in range(2_000):
+        if (fs.root / "test.py") not in project.file_map:
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File not updated after delete")
+    assert len(project.file_map) == 0
+
+    # Recreate file and wait for refresh
+    fs.add_file("test.py", "import recreated")
+    for _ in range(2_000):
+        if (fs.root / "test.py") in project.file_map:
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File not updated after recreation")
+
+    modified_file = project.file_map[fs.root / "test.py"]
+    assert modified_file.contents == "import recreated"
+    assert [c.category for c in modified_file.chunks] == [ChunkCategory.imports]
+
+
+def test_project_watch_modify_deep_file(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("deep/nested/dir/test.py", "def test(): pass")
+    project = FileBreakdownProject(root=fs.root, file_watch_refresh_freq_seconds=0.0)
+    assert len(project.file_map) == 1
+
+    # Modify deep file and wait for refresh
+    (fs.root / "deep/nested/dir/test.py").write_text("import modified")
+    for _ in range(2_000):
+        if project.file_map[fs.root / "deep/nested/dir/test.py"].contents == "import modified":
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File not updated")
+
+    modified_file = project.file_map[fs.root / "deep/nested/dir/test.py"]
+    assert modified_file.contents == "import modified"
+    assert [c.category for c in modified_file.chunks] == [ChunkCategory.imports]
+
+
+def test_project_instantiation_git_ignored_files(tmp_path: Path) -> None:
+    fs = FileSet(tmp_path)
+
+    # Setup git repo
+    repo = Repo.init(fs.root)
+
+    # Create files
+    fs.add_file("tracked.py", "x = 1")
+    fs.add_file("ignored.py", "y = 2")
+
+    # Add gitignore
+    (fs.root / ".gitignore").write_text("ignored.py\n")
+
+    # Add tracked file to git
+    repo.index.add(["tracked.py"])
+    repo.index.commit("Add tracked file")
+
+    project = FileBreakdownProject(root=fs.root)
+    assert len(project.files) == 1
+    assert (fs.root / "tracked.py") in project.file_map
+    assert (fs.root / "ignored.py") not in project.file_map
+
+
+def test_project_git_ignored_file_watch(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test is a bit racy and gross, has a retry loop.
+
+    It's generally tricky to confirm that something doesn't happen, especially when
+    that thing has a nondeterministic delay to it. Oh well. Better imo than digging
+    deep into tests of implementation details.
+    """
+    fs = FileSet(tmp_path)
+    repo = Repo.init(fs.root)
+    (fs.root / ".gitignore").write_text("ignored.py\n")
+
+    # Add tracked file to git
+    fs.add_file("tracked.py", "x = 1")
+    repo.index.add(["tracked.py"])
+    repo.index.commit("Add tracked file")
+
+    # Add ignored file
+    fs.add_file("ignored.py", "y = 2")
+
+    project = FileBreakdownProject(root=fs.root, file_watch_refresh_freq_seconds=0.0)
+    assert len(project.files) == 1
+
+    # Modify ignored file
+    caplog.clear()
+    caplog.set_level(logging.DEBUG)
+    (fs.root / "ignored.py").write_text("y = 3")
+
+    # Wait for ignore message in logs
+    for _ in range(2_000):
+        if f"Ignoring modified for {fs.root / 'ignored.py'}" in caplog.text:
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File was not ignored")
+
+
+def test_project_modify_file_in_dot_git_dir(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Files in .git should be ignored."""
+    fs = FileSet(tmp_path)
+
+    # Setup git repo and add file
+    _repo = Repo.init(fs.root)
+    git_file = fs.root / ".git" / "test.py"
+    git_file.parent.mkdir(exist_ok=True)
+    git_file.write_text("x = 1")
+
+    project = FileBreakdownProject(root=fs.root, file_watch_refresh_freq_seconds=0.0)
+    assert len(project.files) == 0  # No tracked files
+
+    # Modify file in .git
+    caplog.clear()
+    caplog.set_level(logging.DEBUG)
+    git_file.write_text("x = 2")
+
+    # Wait for ignore message in logs
+    for _ in range(2_000):
+        if f"Ignoring modified for {git_file}" in caplog.text:
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError("File in .git was not ignored")
+
+
+def test_project_load_non_existent_file(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    fs = FileSet(tmp_path)
+    fs.add_file("exists.py", "x = 1")
+
+    project = FileBreakdownProject(root=fs.root)
+
+    caplog.clear()
+    caplog.set_level(logging.WARNING)
+    non_existent = fs.root / "does_not_exist.py"
+    project.load_files([fs.root / "does_not_exist.py"])
+
+    # Wait for warning message
+    for _ in range(2_000):
+        if f"File {non_existent} does not exist" in caplog.text:
+            break
+        time.sleep(1e-3)
+    else:
+        raise AssertionError(f"No log message about non-existent file. Caplog is {caplog.text}")
+
+    assert len(project.files) == 1
+    assert fs.root / "exists.py" in project.file_map
+    assert fs.root / "does_not_exist.py" not in project.file_map

--- a/tests/test_rag_tools.py
+++ b/tests/test_rag_tools.py
@@ -1,0 +1,24 @@
+from mcpunk.file_breakdown import Project as FileBreakdownProject
+from mcpunk.tools import PROJECTS, configure_project
+from tests.conftest import FileSet
+
+
+def test_configure_project_basic(
+    basic_file_set: FileSet,
+    test_id: str,
+) -> None:
+    configure_project(root_path=basic_file_set.root, project_name=test_id)
+    assert test_id in PROJECTS
+    chunk_project = PROJECTS[test_id].chunk_project
+
+    # Check that the chunk project created by the tool is the same as one created
+    # by hand here. The point of this is to just check that the tool is instantiating
+    # the project appropriately.
+    expected_chunk_project = FileBreakdownProject(root=basic_file_set.root)
+    expected_serialised_file_map = {
+        str(x.abs_path): x.model_dump(mode="json") for x in expected_chunk_project.files
+    }
+    actual_serialised_file_map = {
+        str(x.abs_path): x.model_dump(mode="json") for x in chunk_project.files
+    }
+    assert actual_serialised_file_map == expected_serialised_file_map

--- a/uv.lock
+++ b/uv.lock
@@ -400,6 +400,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tzlocal" },
     { name = "uvicorn" },
+    { name = "watchdog" },
 ]
 
 [package.optional-dependencies]
@@ -432,6 +433,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = "~=2.0.36" },
     { name = "tzlocal", specifier = "~=5.2" },
     { name = "uvicorn", specifier = ">=0.34.0,<1.0.0" },
+    { name = "watchdog", specifier = "~=6.0.0" },
 ]
 
 [[package]]
@@ -959,4 +961,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/39/689abee4adc85aad2af8174bb195a819d0be064bf55fcc73b49d2b28ae77/virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329", size = 7650532 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/8f/dfb257ca6b4e27cb990f1631142361e4712badab8e3ca8dc134d96111515/virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb", size = 4276719 },
+]
+
+[[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/24/d9be5cd6642a6aa68352ded4b4b10fb0d7889cb7f45814fb92cecd35f101/watchdog-6.0.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6eb11feb5a0d452ee41f824e271ca311a09e250441c262ca2fd7ebcf2461a06c", size = 96393 },
+    { url = "https://files.pythonhosted.org/packages/63/7a/6013b0d8dbc56adca7fdd4f0beed381c59f6752341b12fa0886fa7afc78b/watchdog-6.0.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ef810fbf7b781a5a593894e4f439773830bdecb885e6880d957d5b9382a960d2", size = 88392 },
+    { url = "https://files.pythonhosted.org/packages/d1/40/b75381494851556de56281e053700e46bff5b37bf4c7267e858640af5a7f/watchdog-6.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:afd0fe1b2270917c5e23c2a65ce50c2a4abb63daafb0d419fde368e272a76b7c", size = 89019 },
+    { url = "https://files.pythonhosted.org/packages/39/ea/3930d07dafc9e286ed356a679aa02d777c06e9bfd1164fa7c19c288a5483/watchdog-6.0.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdd4e6f14b8b18c334febb9c4425a878a2ac20efd1e0b231978e7b150f92a948", size = 96471 },
+    { url = "https://files.pythonhosted.org/packages/12/87/48361531f70b1f87928b045df868a9fd4e253d9ae087fa4cf3f7113be363/watchdog-6.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c7c15dda13c4eb00d6fb6fc508b3c0ed88b9d5d374056b239c4ad1611125c860", size = 88449 },
+    { url = "https://files.pythonhosted.org/packages/5b/7e/8f322f5e600812e6f9a31b75d242631068ca8f4ef0582dd3ae6e72daecc8/watchdog-6.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6f10cb2d5902447c7d0da897e2c6768bca89174d0c6e1e30abec5421af97a5b0", size = 89054 },
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480 },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451 },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057 },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079 },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076 },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077 },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078 },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065 },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070 },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067 },
 ]


### PR DESCRIPTION
Closes #38

This is a fairly simple implementation where `watchdog` is used to watch for changes on the filesystem. Each change is appended to a 'pending refresh' list. And every 100ms (by default) the code refreshes them in bulk. This 100ms interval allows things to accumulate, thus allowing for sensible multiprocessing. And it avoids things like where IDEs create temporary files (pycharm seems to do this on save).

It's quite possibly a bit racy. I haven't intended to make it bullet proof, and can always do a second pass on it.