### PR TITLE
Split large chunks

### DIFF
--- a/mcpunk/file_breakdown.py
+++ b/mcpunk/file_breakdown.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from threading import Lock, Timer
 from typing import Literal
 
+import more_itertools
 from git import Repo
 from pydantic import (
     BaseModel,
@@ -180,6 +181,7 @@ class File(BaseModel):
             if chunker.can_chunk(source_code, file_path):
                 try:
                     chunks = chunker(source_code, file_path).chunk_file()
+                    chunks = list(more_itertools.flatten(x.split(max_size=10_000) for x in chunks))
                     break
                 except Exception:
                     logger.exception(f"Error chunking file {file_path} with {chunker}")

--- a/mcpunk/file_breakdown.py
+++ b/mcpunk/file_breakdown.py
@@ -172,6 +172,7 @@ class File(BaseModel):
         cls,
         source_code: str,
         file_path: Path,
+        max_chunk_size: int = 10_000,
     ) -> "File":
         """Extract all callables, calls and imports from the given source code file."""
         chunks: list[Chunk] = []
@@ -181,7 +182,9 @@ class File(BaseModel):
             if chunker.can_chunk(source_code, file_path):
                 try:
                     chunks = chunker(source_code, file_path).chunk_file()
-                    chunks = list(more_itertools.flatten(x.split(max_size=10_000) for x in chunks))
+                    chunks = list(
+                        more_itertools.flatten(x.split(max_size=max_chunk_size) for x in chunks),
+                    )
                     break
                 except Exception:
                     logger.exception(f"Error chunking file {file_path} with {chunker}")
@@ -203,9 +206,11 @@ class Project:
         root: Path,
         files_per_parallel_worker: int = 100,
         file_watch_refresh_freq_seconds: float = 0.1,
+        max_chunk_size: int = 10_000,
     ) -> None:
         self.root = root.expanduser().absolute()
         self.files_per_parallel_worker = files_per_parallel_worker
+        self.max_chunk_size = max_chunk_size
         self.file_map: dict[Path, File] = {}
 
         git_repo: Repo | None
@@ -243,14 +248,21 @@ class Project:
 
         files_analysed: list[File]
         if n_workers == 1:
-            files_analysed_maybe_none = [_analyze_file(file_path) for file_path in files]
+            files_analysed_maybe_none = [
+                _analyze_file(file_path, max_chunk_size=self.max_chunk_size) for file_path in files
+            ]
             files_analysed = [x for x in files_analysed_maybe_none if x is not None]
         else:
             logger.info(f"Using {n_workers} workers to process {len(files)} files")
             files_analysed = []
             with ProcessPoolExecutor(max_workers=n_workers) as executor:
                 future_to_file = {
-                    executor.submit(_analyze_file, file_path): file_path for file_path in files
+                    executor.submit(
+                        _analyze_file,
+                        file_path,
+                        max_chunk_size=self.max_chunk_size,
+                    ): file_path
+                    for file_path in files
                 }
 
                 for future in as_completed(future_to_file):
@@ -289,7 +301,7 @@ class Project:
         self.load_files(files)
 
 
-def _analyze_file(file_path: Path) -> File | None:
+def _analyze_file(file_path: Path, max_chunk_size: int = 10_000) -> File | None:
     try:
         if not file_path.exists():
             logger.warning(f"File {file_path} does not exist")
@@ -298,7 +310,11 @@ def _analyze_file(file_path: Path) -> File | None:
             logger.warning(f"File {file_path} is not a file")
             return None
 
-        return File.from_file_contents(file_path.read_text(), file_path)
+        return File.from_file_contents(
+            file_path.read_text(),
+            file_path,
+            max_chunk_size=max_chunk_size,
+        )
     except Exception:
         logger.exception(f"Error processing file {file_path}")
         return None

--- a/mcpunk/file_chunk.py
+++ b/mcpunk/file_chunk.py
@@ -76,3 +76,81 @@ class Chunk(BaseModel):
         else:
             assert_never(filter_on)
         return matches_filter(filter_, data)
+
+    def split(
+        self,
+        max_size: int = 10_000,
+        split_chunk_prefix: str = (
+            "[This is a subsection of the chunk. Other parts contain the rest of the chunk]\n\n"
+        ),
+    ) -> list["Chunk"]:
+        """Split this chunk into smaller chunks.
+
+        This will split the chunk at line boundaries, unless the
+        line is already longer than max_size.
+
+        Args:
+            max_size: Maximum size in characters for the chunk contents. At least 100.
+            split_chunk_prefix: Prefix to add the start of each newly created split chunk.
+                Unused if the chunk is not split. You can set to empty string to
+                suppress the prefix.
+
+        Returns:
+            List containing either the original chunk (if small enough) or multiple smaller chunks
+        """
+        assert max_size >= 100, "max_size must be at least 100"
+        # If chunk is small enough, return it as is
+        if len(self.content) <= max_size:
+            return [self]
+        max_size -= len(split_chunk_prefix)
+        assert max_size > 0, f"{max_size} maybe decrease prefix length"
+
+        result: list[Chunk] = []
+        max_line_size = max_size - 50  # Leave some margin
+
+        # Preprocess to split long lines first. This could be avoided, but it does
+        # make the whole thing a bit simpler as we always know later on that a single line
+        # will never be longer than max_size.
+        processed_lines = []
+        for line in self.content.splitlines(keepends=True):
+            if len(line) > max_line_size:
+                # Split the line into chunks of max_line_size
+                for i in range(0, len(line), max_line_size):
+                    processed_lines.append(line[i : i + max_line_size])
+            else:
+                processed_lines.append(line)
+
+        # Now split into chunks of max_size
+        current_content: list[str] = []
+        current_size = 0
+        part_num = 1
+
+        for line in processed_lines:
+            # If adding this line would exceed the limit, create a new chunk
+            if current_size + len(line) > max_size and current_content:
+                new_chunk = Chunk(
+                    category=self.category,
+                    name=f"{self.name}_part{part_num}",
+                    content=split_chunk_prefix + "".join(current_content),
+                    line=None,
+                )
+                result.append(new_chunk)
+                part_num += 1
+                current_content = []
+                current_size = 0
+
+            # Add the line to the current chunk
+            current_content.append(line)
+            current_size += len(line)
+
+        # Add the final chunk if there's anything left
+        if current_content:
+            new_chunk = Chunk(
+                category=self.category,
+                name=f"{self.name}_part{part_num}",
+                content=split_chunk_prefix + "".join(current_content),
+                line=None,
+            )
+            result.append(new_chunk)
+
+        return result

--- a/mcpunk/settings.py
+++ b/mcpunk/settings.py
@@ -53,6 +53,11 @@ class Settings(BaseSettings):
     # files during save (though this is not a guarantee).
     file_watch_refresh_freq_seconds: float = 0.1
 
+    # Maximum size of a chunk in characters. If a chunk is larger than this,
+    # it will be split into multiple chunks. A chunk is something like a function,
+    # or maybe a whole file (depends on the chunker).
+    max_chunk_size: int = 10_000
+
     @property
     def task_queue_visibility_timeout(self) -> timedelta:
         return timedelta(seconds=self.task_queue_visibility_timeout_seconds)

--- a/mcpunk/settings.py
+++ b/mcpunk/settings.py
@@ -36,7 +36,8 @@ class Settings(BaseSettings):
     include_chars_in_response: bool = True
     # Maximum number of characters in the response. If the response is longer than this
     # then an error will be returned to the caller. This is handy to avoid blowing
-    # your context.
+    # your context. HOWEVER this is largely redundant with the max_chunk_size
+    # option. Likely to be removed in the future.
     default_response_max_chars: int = 20_000
     # Same as `default_response_max_chars` but for the tool that returns a git diff.
     # Generally, git diffs are a bit larger than e.g. a function so nice to have it a

--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -372,6 +372,9 @@ def find_matching_chunks_in_file(
         (e.g. find_matching_chunks_in_file(..., ["my_funk"])
       - Finding a chunk where a specific function is defined
         (e.g. find_matching_chunks_in_file(..., ["def my_funk"])
+
+    Some chunks are split into multiple parts, because they are too large. This
+    will look like 'chunkx_part1', 'chunkx_part2', ...
     """
     proj_file = ProjectFile(project_name=project_name, rel_path=rel_path)
     return _list_chunks_in_file(proj_file, filter_, "name_or_content").render()

--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -371,8 +371,6 @@ def find_matching_chunks_in_file(
         (e.g. find_matching_chunks_in_file(..., ["my_funk"])
       - Finding a chunk where a specific function is defined
         (e.g. find_matching_chunks_in_file(..., ["def my_funk"])
-
-    Returns array of {n: name, t: type, id: identifier, chars: length}
     """
     proj_file = ProjectFile(project_name=project_name, rel_path=rel_path)
     return _list_chunks_in_file(proj_file, filter_, "name_or_content").render()

--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -259,6 +259,7 @@ def configure_project(
         chunk_project=FileBreakdownProject(
             root=path,
             file_watch_refresh_freq_seconds=deps.settings().file_watch_refresh_freq_seconds,
+            max_chunk_size=deps.settings().max_chunk_size,
         ),
     )
     PROJECTS[project_name] = project

--- a/tests/test_file_chunk.py
+++ b/tests/test_file_chunk.py
@@ -1,0 +1,330 @@
+from mcpunk.file_chunk import Chunk, ChunkCategory
+
+
+def test_chunk_id_consistency() -> None:
+    """Test that identical chunks produce the same ID."""
+    chunk1 = Chunk(
+        category=ChunkCategory.callable,
+        name="test_func",
+        line=10,
+        content="def test_func():\n    return True",
+    )
+    chunk2 = Chunk(
+        category=ChunkCategory.callable,
+        name="test_func",
+        line=10,
+        content="def test_func():\n    return True",
+    )
+    assert chunk1.id_ == chunk2.id_
+
+
+def test_chunk_id_uniqueness() -> None:
+    """Test that different chunks produce different IDs."""
+    chunk1 = Chunk(
+        category=ChunkCategory.callable,
+        name="func1",
+        line=10,
+        content="def func1():\n    return True",
+    )
+    chunk2 = Chunk(
+        category=ChunkCategory.callable,
+        name="func2",  # Different name
+        line=10,
+        content="def func1():\n    return True",
+    )
+    chunk3 = Chunk(
+        category=ChunkCategory.callable,
+        name="func1",
+        line=20,  # Different line
+        content="def func1():\n    return True",
+    )
+    chunk4 = Chunk(
+        category=ChunkCategory.callable,
+        name="func1",
+        line=10,
+        content="def func1():\n    return False",  # Different content
+    )
+
+    assert chunk1.id_ != chunk2.id_
+    assert chunk1.id_ != chunk3.id_
+    assert chunk1.id_ != chunk4.id_
+
+
+def test_chunk_id_format() -> None:
+    """Test that the ID follows the expected format: name_hash."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="test_func",
+        line=10,
+        content="def test_func():\n    return True",
+    )
+    chunk_id = chunk.id_
+    # ID should start with the chunk name followed by underscore
+    assert chunk_id.startswith("test_func_")
+    # The rest should be a 10-character hash
+    hash_part = chunk_id[len("test_func_") :]
+    assert len(hash_part) == 10
+    # Hash should be hexadecimal (0-9, a-f)
+    assert all(c in "0123456789abcdef" for c in hash_part)
+
+
+def test_chunk_matches_filter_string_on_name() -> None:
+    """Test that a string filter matches when present in chunk name."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="test_function",
+        line=1,
+        content="def test_function():\n    pass",
+    )
+    assert chunk.matches_filter("function", "name") is True
+    assert chunk.matches_filter("test", "name") is True
+    assert chunk.matches_filter("test_function", "name") is True
+
+
+def test_chunk_matches_filter_list_on_name() -> None:
+    """Test that a list filter matches when any element is in chunk name."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="test_function",
+        line=1,
+        content="def test_function():\n    pass",
+    )
+    assert chunk.matches_filter(["func", "other"], "name") is True
+    assert chunk.matches_filter(["test", "xyz"], "name") is True
+    assert chunk.matches_filter(["unrelated", "test_function"], "name") is True
+
+
+def test_chunk_matches_filter_none() -> None:
+    """Test that None filter matches all chunks."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="test_function",
+        line=1,
+        content="def test_function():\n    pass",
+    )
+    assert chunk.matches_filter(None, "name") is True
+    assert chunk.matches_filter(None, "content") is True
+    assert chunk.matches_filter(None, "name_or_content") is True
+
+
+def test_chunk_matches_filter_on_content() -> None:
+    """Test filtering on content."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="test_function",
+        line=1,
+        content="def test_function():\n    return 'hello world'",
+    )
+    assert chunk.matches_filter("hello", "content") is True
+    assert chunk.matches_filter("return", "content") is True
+    assert chunk.matches_filter(["world", "planet"], "content") is True
+    assert chunk.matches_filter("not_present", "content") is False
+
+
+def test_chunk_matches_filter_on_name_or_content() -> None:
+    """Test filtering on both name and content combined."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="example_function",
+        line=1,
+        content="def test_function():\n    return 'hello'",
+    )
+    assert chunk.matches_filter("example", "name_or_content") is True
+    assert chunk.matches_filter("hello", "name_or_content") is True
+    assert chunk.matches_filter("function", "name_or_content") is True
+
+
+def test_chunk_matches_filter_non_matching() -> None:
+    """Test various non-matching cases."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="test_function",
+        line=1,
+        content="def test_function():\n    pass",
+    )
+    assert chunk.matches_filter("missing", "name") is False
+    assert chunk.matches_filter(["absent", "not_here"], "name") is False
+    assert chunk.matches_filter("return", "content") is False
+    assert chunk.matches_filter("missing", "name_or_content") is False
+
+
+def test_chunk_split_small_chunk_not_split() -> None:
+    """Test that small chunks (below max_size) aren't split."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="small_func",
+        line=1,
+        content="Small content that is definitely below default max_size",
+    )
+    result = chunk.split()
+    assert len(result) == 1
+    assert result[0] is chunk  # It should return the original object, not a copy
+
+
+def test_chunk_split_at_line_boundaries() -> None:
+    """Test that chunks are split at line boundaries when possible."""
+    # Create multi-line content where each line is below max_line_size
+    lines = [f"Line {i}" + "x" * 50 for i in range(20)]
+    content = "\n".join(lines)
+    chunk = Chunk(category=ChunkCategory.callable, name="multi_line_func", line=1, content=content)
+
+    # Choose a max_size that will require splitting but allow multiple lines per chunk
+    max_size = 300
+    result = chunk.split(max_size=max_size, split_chunk_prefix="blah")
+
+    assert len(result) > 1
+    for chunk_idx, r in enumerate(result):
+        assert len(r.content) <= max_size, f"Chunk {chunk_idx} exceeds max_size"
+
+    prefix_len = len("blah")
+
+    # Verify splits occur at line boundaries
+    for i in range(len(result) - 1):  # Check all but the last chunk
+        chunk_content = result[i].content[prefix_len:]
+        # Each non-final chunk should end with a newline
+        assert chunk_content.endswith("\n"), f"Chunk {i} doesn't end at a line boundary"
+
+    # Verify no line is split across chunks (by checking each original line is fully in one chunk)
+    for line in lines:
+        # Count how many chunks contain this exact line (should be exactly 1)
+        line_with_newline = line + "\n"
+        found_in_chunks = 0
+        for r in result:
+            chunk_content = r.content[prefix_len:]
+            if line_with_newline in chunk_content:
+                found_in_chunks += 1
+
+        # The last line doesn't have a newline
+        if line == lines[-1]:
+            line_no_newline = line
+            for r in result:
+                chunk_content = r.content[prefix_len:]
+                if chunk_content.endswith(line_no_newline):
+                    found_in_chunks += 1
+
+        assert found_in_chunks == 1
+
+    # The combined content (without prefixes) should match original content
+    reconstructed = ""
+    for r in result:
+        reconstructed += r.content[prefix_len:]
+    assert reconstructed == content
+
+
+def test_chunk_split_very_long_single_line() -> None:
+    """Test that very long single lines are split correctly."""
+    long_line = "x" * 5000  # Single line, no newlines
+    chunk = Chunk(category=ChunkCategory.callable, name="long_line_func", line=1, content=long_line)
+
+    max_size = 1000
+    result = chunk.split(max_size=max_size, split_chunk_prefix="blah")
+
+    assert len(result) > 1, "Long line should be split into multiple chunks"
+
+    for chunk_idx, r in enumerate(result):
+        assert len(r.content) <= max_size, f"Chunk {chunk_idx} exceeds max_size"
+
+    # The prefix length for first and subsequent chunks
+    prefix_len = len("blah")
+
+    # Reconstruct original content without prefixes
+    reconstructed = ""
+    for r in result:
+        reconstructed += r.content[prefix_len:]
+
+    assert reconstructed == long_line, "Reconstructed content doesn't match original"
+
+
+def test_chunk_split_naming_convention() -> None:
+    """Test that split chunks follow the expected naming convention."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="original_name",
+        line=1,
+        content="\n".join(["x" * 100 for _ in range(10)]),  # Content that will be split
+    )
+
+    result = chunk.split(max_size=200)
+
+    assert len(result) > 1, "Content should be split into multiple chunks"
+
+    # Check naming pattern: original_name_part1, original_name_part2, etc.
+    for i, r in enumerate(result, 1):
+        assert r.name == f"original_name_part{i}", f"Incorrect name for chunk {i}"
+
+    # Verify other properties are maintained or adjusted as expected
+    for r in result:
+        assert r.category == chunk.category, "Category should be preserved"
+        assert r.line is None, "Line number should be None for split chunks"
+
+
+def test_chunk_split_custom_prefix() -> None:
+    """Test that custom prefixes are applied correctly to split chunks."""
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="test_func",
+        line=1,
+        content="\n".join(["x" * 100 for _ in range(10)]),
+    )
+
+    # Test with custom prefix
+    custom_prefix = "CUSTOM PREFIX: "
+    result = chunk.split(max_size=200, split_chunk_prefix=custom_prefix)
+
+    assert len(result) > 1, "Content should be split into multiple chunks"
+
+    # Each chunk should start with the custom prefix
+    for chunk_idx, r in enumerate(result):
+        assert r.content.startswith(custom_prefix), f"Chunk {chunk_idx} doesn't have custom prefix"
+
+    # Test with empty prefix
+    empty_result = chunk.split(max_size=200, split_chunk_prefix="")
+
+    # Chunks should start with content, not the default prefix
+    for chunk_idx, r in enumerate(empty_result):
+        assert r.content.startswith("x"), f"Chunk {chunk_idx} doesn't start with expected content"
+        assert not r.content.startswith(
+            "[This is",
+        ), "Default prefix was used despite empty custom prefix"
+
+
+def test_chunk_split_content_preservation() -> None:
+    """Test that splitting preserves all original content."""
+    # Create content with distinct lines for easier verification
+    lines = [f"Line {i} with unique content" for i in range(20)]
+    content = "\n".join(lines)
+    chunk = Chunk(category=ChunkCategory.callable, name="test_func", line=1, content=content)
+
+    # Use empty prefix to simplify content reconstruction
+    result = chunk.split(max_size=300, split_chunk_prefix="")
+
+    combined = "".join(r.content for r in result)
+
+    # Should exactly match original content
+    assert combined == content, "Content was not preserved during splitting"
+
+    # Verify specific lines are preserved
+    for i, line in enumerate(lines):
+        assert line in combined, f"Line {i} is missing from reconstructed content"
+
+
+def test_chunk_split_empty_content() -> None:
+    """Test that empty content is handled correctly."""
+    chunk = Chunk(category=ChunkCategory.callable, name="empty_func", line=1, content="")
+    result = chunk.split()
+    assert len(result) == 1, "Empty content should result in a single chunk"
+    assert result[0] is chunk, "Should return the original chunk for empty content"
+
+
+def test_chunk_split_exactly_at_max_size() -> None:
+    """Test content that is exactly at the max_size limit."""
+    exact_content = "x" * 1000
+    chunk = Chunk(
+        category=ChunkCategory.callable,
+        name="exact_size_func",
+        line=1,
+        content=exact_content,
+    )
+    result = chunk.split(max_size=1000)
+    assert len(result) == 1, "Content exactly at max_size should not be split"
+    assert result[0] is chunk, "Should return the original chunk when exactly at max_size"


### PR DESCRIPTION
Now chunks over 10k chars (configurable) are split up, to be under 10k chars. Previously these would just be large chunks and the `default_response_max_chars` option (with a default of 20k chars) would mean that the LLM couldn't see them, and generally in my experience the LLM would just guess things as a result. So basically large functions and large whole files are now happy.