### PR TITLE
`chunk_details` tool uses chunk_id only, looks up project/file itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,10 @@ In this case the LLM should recognise this via imports.
 - "Large" projects are not well tested. A project with ~1000 Python files containing
   in total ~250k LoC works well. Takes ~5s to setup the project. As codebase
   size increases, time to perform initial chunking will increase, and likely
-  more sophisticated searching will be required.
+  more sophisticated searching will be required. The code is generally not
+  written with massive codebases in mind - you will see things like all data
+  stored in memory, searching done by iterating over all data, various
+  things that are screaming out for basic optimisation.
 
 # Configuration
 


### PR DESCRIPTION
Closes #40

Now the LLM doesn't have to repeatedly specify the project name and file path when grabbing chunk details 👍

Involves a little vile brute search but oh well, can come back to it if anyone complains about perf. Preparing e.g. a dict for lookup is not totally trivial since things things are updated upon file refresh in the background. But shouldn't be hard.