### PR TITLE
Empty string/list matches all

### DIFF
--- a/mcpunk/tools.py
+++ b/mcpunk/tools.py
@@ -40,7 +40,12 @@ ToolResponseSequence = Sequence[ToolResponseSingleItem]
 ToolResponse = ToolResponseSequence | ToolResponseSingleItem
 FilterType = Annotated[
     str | list[str] | None,
-    Field(description="Match if any of these strings appear. Match all if None/null."),
+    Field(
+        description=(
+            "Match if any of these strings appear. Match all if None/null. "
+            "Single empty string or empty list will match all."
+        ),
+    ),
 ]
 
 

--- a/mcpunk/util.py
+++ b/mcpunk/util.py
@@ -135,12 +135,17 @@ def matches_filter(filter_: None | list[str] | str, data: str | None) -> bool:
 
     filter_ can be:
     - None matches all data
-    - str matches if the data contains the string
-    - list[str] matches if the data contains any of the strings in the list
+    - str matches if the data contains the string. Empty string matches all.
+    - list[str] matches if the data contains any of the strings in the list. Empty list matches all.
+
+    I find the LLM likes to use an empty list to mean "all" even though it should probably
+    use None so 🤷
 
     if data is None it never matches (unless filter_ is None)
     """
     if filter_ is None:
+        return True
+    if len(filter_) == 0:
         return True
     if data is None:
         return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -157,3 +157,8 @@ def test_matches_filter() -> None:
     assert matches_filter(["abc", "def"], "abcdef") is True
     assert matches_filter(["xyz", "123"], "abcdef") is False
     assert matches_filter(["abc"], None) is False
+
+    # Empty string matches all
+    assert matches_filter("", "abcdef") is True
+    # Empty list matches all
+    assert matches_filter([], "abcdef") is True


### PR DESCRIPTION
I find the LLM likes to use an empty list to mean "all" even though it should probably use None so 🤷